### PR TITLE
Migration improvements + prepare for final release (Expressive 3.0 stable)

### DIFF
--- a/src/MigrateCommand.php
+++ b/src/MigrateCommand.php
@@ -228,8 +228,6 @@ class MigrateCommand extends Command
         ) {
             $composer['config']['platform']['php'] = '7.1.3';
         }
-        // todo: remove this entry after zend-expressive release
-        $composer['minimum-stability'] = 'alpha';
 
         $this->updateComposer($composer);
 

--- a/src/MigrateCommand.php
+++ b/src/MigrateCommand.php
@@ -76,16 +76,14 @@ class MigrateCommand extends Command
             return 1;
         }
 
-        $expressive = $packages['zendframework/zend-expressive'];
-        if (preg_match('/\d+\.\d+(\.\d+)?/', $expressive['constraint'], $matches)) {
-            $version = $matches[0];
-        } elseif (file_exists('composer.lock')) {
+        if (file_exists('composer.lock')) {
             $lock = json_decode(file_get_contents('composer.lock'), true);
             foreach ($lock['packages'] as $package) {
                 if (strtolower($package['name']) === 'zendframework/zend-expressive'
                     && preg_match('/\d+\.\d+(\.\d+)?/', $package['version'], $matches)
                 ) {
                     $version = $matches[0];
+                    break;
                 }
             }
         }

--- a/src/MigrateCommand.php
+++ b/src/MigrateCommand.php
@@ -427,7 +427,7 @@ class MigrateCommand extends Command
             $version
         );
 
-        return file_get_contents($uri . 'public/index.php');
+        return file_get_contents($uri . $path);
     }
 
     private function addFunctionWrapper(string $file) : bool


### PR DESCRIPTION
- detecting currently installed expressive version only based on `composer.lock` - it's better way and more reliable, because in `composer.json` we can have many constraints
- detecting the latest version of skeleton from packagist.org
- fixed getting file content from skeleton - it was always retrieving the `index.php` content, but we need to request it for different files (when updating containers configuration; e.g. pimple, aura.di)
- removed setting minimum-stability in composer - no longer required as Expressive 3.0 stable is released.