### PR TITLE
Fix installing zend-diactoros on migration

### DIFF
--- a/src/MigrateCommand.php
+++ b/src/MigrateCommand.php
@@ -219,7 +219,6 @@ class MigrateCommand extends Command
     {
         exec('rm -Rf vendor');
         exec('composer install --no-interaction');
-        exec('composer require "zendframework/zend-diactoros:^1.7.1"');
 
         $composer = $this->getComposerContent();
         $composer['config']['sort-packages'] = true;
@@ -294,7 +293,7 @@ class MigrateCommand extends Command
             }
         }
 
-        $require = [];
+        $require = ['zendframework/zend-diactoros'];
         $requireDev = [];
         foreach ($packages as $name => $package) {
             if ($package['dev']) {
@@ -316,8 +315,8 @@ class MigrateCommand extends Command
                 implode(' ', array_merge($require, $requireDev, $extraRequire, $extraRequireDev))
             ),
             sprintf('composer update --no-interaction'),
-            sprintf('composer require --dev %s --no-interaction', implode(' ', $requireDev)),
             sprintf('composer require %s --no-interaction', implode(' ', $require)),
+            sprintf('composer require --dev %s --no-interaction', implode(' ', $requireDev)),
             sprintf('composer require %s --no-interaction', implode(' ', $extraRequire)),
             sprintf('composer require --dev %s --no-interaction', implode(' ', $extraRequireDev)),
         ];


### PR DESCRIPTION
When it was explicitly required it was updated and then removed.
It should be always required on migration as Expressive v2 required it, and in Expressive v3 we can use any PSR-7 implementation. For compatibility it should be installed, and then it could be changed manually to another implementation.

Fixes #11 

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
  - [x] Detail the original, incorrect behavior.
  - [x] Detail the new, expected behavior.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [x] ~Add a regression test that demonstrates the bug, and proves the fix.~ - manual tests on https://github.com/weirdan/z-e-m-dep-bug repo
  - [ ] Add a `CHANGELOG.md` entry for the fix.

/cc @weirdan